### PR TITLE
Bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   "authors": [
     "Nolan Lawson <nolan.lawson@gmail.com>"
   ],
-  "description": "https://github.com/nolanlawson/pouchdb-authentication",
+  "description": "Easy authentication plugin for PouchDB/CouchDB",
   "keywords": [
     "pouchdb",
     "couchdb",


### PR DESCRIPTION
I was getting a bower EMALFORMED error when attempting to bower install.  Stack overflow suggested that a  leading invisible unicode character might be to blame, so I regenerated and bumped the release to fix.  I also noticed that main was pointing to index.js ... so I updated it to the dist file.  This plays nicely with gulp-bower and wiredep.
