### PR TITLE
Added `metadata` to reservedWords for signUp() #37

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ exports.signup = utils.toPromise(function (username, password, opts, callback) {
     _id      : userId
   };
 
-  var reservedWords = ['name', 'password', 'roles', 'type'];
+  var reservedWords = ['name', 'password', 'roles', 'type', 'metadata'];
   if (opts.metadata) {
     for (var key in opts.metadata) {
       if (opts.hasOwnProperty(key)) {


### PR DESCRIPTION
I found the issue in my problem; I was sending the entire `user` object, not just `user.metadata`. This breaks and doesn't throw a Auth error if `metadata` is a field in the `metadata` parameter for signup - instead, it throws a breaking `undefined is not a function` and doesn't have an error which you can log as to why signing up didn't work. Adding `metadata` to the list of reserved words should fix that. 

 