### PR TITLE
Added salt as a reserved word

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ exports.signup = utils.toPromise(function (username, password, opts, callback) {
     _id      : userId
   };
 
-  var reservedWords = ['name', 'password', 'roles', 'type'];
+  var reservedWords = ['name', 'password', 'roles', 'type', 'salt'];
   if (opts.metadata) {
     for (var key in opts.metadata) {
       if (opts.hasOwnProperty(key)) {


### PR DESCRIPTION
PouchDB uses `salt` natively; if you try to have a `salt` field in `metadata` it will be rewritten and you may have bugs in your code.