### PR TITLE
Added triple slash replace to remove illegal_database_name err #39

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,10 +6,12 @@ function getBaseUrl(db) {
   return db.getUrl().replace(/\/[^\/]+\/?$/, '');
 }
 exports.getUsersUrl = function (db) {
-  return getBaseUrl(db) + '/_users';
+  var url = getBaseUrl(db) + '/_users';
+  return url.replace('\/\/\/', '/');
 };
 exports.getSessionUrl = function (db) {
-  return getBaseUrl(db) + '/_session';
+  var url = getBaseUrl(db) + '/_session';
+  return url.replace('\/\/\/', '/');
 };
 exports.once = function (fun) {
   var called = false;


### PR DESCRIPTION
The current regex that is being run in getBaseUrl(db) can result in triple slashes being present in the url for Users and Sessions. This seems to throw an error sometimes when CouchDB doesn't like a database name, which it thinks the special case of _sessions and _users to be, starting with an underscore (a db name must start with a letter). This is a crude fix to stop that.