### PR TITLE
Switch login to use x-www-form-urlencoded

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -82,7 +82,8 @@ exports.login = utils.toPromise(function (username, password, opts, callback) {
   var ajaxOpts = utils.extend(true, {
     method : 'POST',
     url : utils.getSessionUrl(db),
-    body : {name : username, password : password}
+    headers : {'Content-Type': 'application/x-www-form-urlencoded'},
+    body : 'name=' + username + '&password=' + password
   }, opts.ajax || {});
   utils.ajax(ajaxOpts, wrapError(callback));
 });


### PR DESCRIPTION
Which makes login() work for Cloudant and old CouchDB.


So...this doesn't fix everything, but it does fix the most important thing. :smile: 

`logout()` and `getSession()` have always worked just fine on Cloudant--which is (probably) why I'd overlooked the fact that I couldn't login. :frowning: 

With this change, you can use "stock" Cloudant login info with this library and (presumably) use a `_users` db setup also.

The `signup` situation (needing passwords pre-hashed) could be alleviated by some basic how-to docs or an optional `prepForSignUp` (or something less poorly named...) to do the password hashing for old CouchDB's and Cloudant.

@willholley this may be useful for you and yours. :wink: