### PR TITLE
send login data as JSON

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,8 +86,8 @@ exports.login = utils.toPromise(function (username, password, opts, callback) {
   var ajaxOpts = utils.extend(true, {
     method : 'POST',
     url : utils.getSessionUrl(db),
-    headers : {'Content-Type': 'application/x-www-form-urlencoded'},
-    body : 'name=' + encodeURIComponent(username) + '&password=' + encodeURIComponent(password)
+    headers : {'Content-Type': 'application/json'},
+    body : JSON.stringify({name: username, password: password})
   }, opts.ajax || {});
   utils.ajax(ajaxOpts, wrapError(callback));
 });


### PR DESCRIPTION
Set the content-type to `application/json` and send the login data as stringified JSON.

Per @skiqh's [work-around](https://github.com/nolanlawson/pouchdb-authentication/issues/111#issuecomment-242810853) in #111 

For anyone else with the issue in the meantime, you can use his fork:

`npm i --save https://github.com/skiqh/pouchdb-authentication.git\#patch-1`